### PR TITLE
style: Fix incorrect named parameter

### DIFF
--- a/inspektor/style.py
+++ b/inspektor/style.py
@@ -58,7 +58,7 @@ class StyleChecker(object):
                                            '--ignore',
                                            self.ignored_errors,
                                            '--in-place'])[0]
-            autopep8.fix_file(path, options=opt_obj)
+            autopep8.fix_file(path, opts=opt_obj)
         return runner.check_all() == 0
 
     def check(self, path):


### PR DESCRIPTION
autopep8.fix_file accepts opts, not options

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
