### PR TITLE
Make version number (0.4.5) visible on command line tool

### DIFF
--- a/inspektor/cli/app.py
+++ b/inspektor/cli/app.py
@@ -26,7 +26,7 @@ class InspektorApp(App):
     def __init__(self):
         super(InspektorApp, self).__init__(
             description='Inspektor python code checker and fixer',
-            version='0.4.0',
+            version='0.4.5',
             command_manager=CommandManager('inspektor.app'),
             deferred_help=True,
             )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, find_packages
 
 PROJECT = 'inspektor'
 
-# Change docs/sphinx/conf.py too!
+# Change docs/sphinx/conf.py and inspektor/cli/app.py
 VERSION = '0.4.5'
 
 REQUIRES = ['six']


### PR DESCRIPTION
Running `inspekt --version` returns version 0.4.0.  Looks like the
last version bump missed that.

Signed-off-by: Cleber Rosa <crosa@redhat.com>