### PR TITLE
inspektor/lint.py: remove unused method `set_verbose()`

### DIFF
--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -49,9 +49,6 @@ class Linter(object):
         else:
             self.log.info('Verbose mode, no disable/enable, full reports')
 
-    def set_verbose(self):
-        self.verbose = True
-
     @staticmethod
     def _pylint_has_option(option):
         return option in _PYLINT_HELP_TEXT


### PR DESCRIPTION
I didn't find any use for this method, and the attribute it sets is
public.

Signed-off-by: Cleber Rosa <crosa@redhat.com>