### PR TITLE
Allow parallel lint and remove broken "verbose" mode

### DIFF
--- a/inspektor/commands/checkall.py
+++ b/inspektor/commands/checkall.py
@@ -69,8 +69,6 @@ class CheckAllCommand(Command):
         parser.add_argument('--author', type=str,
                             help='Author string. Ex: "Author: Brandon Lindon <brandon.lindon@foocorp.com>"',
                             default="")
-        parser.add_argument('--verbose', action='store_true',
-                            help='Print extra debug messages')
         return parser
 
     def take_action(self, parsed_args):

--- a/inspektor/commands/checkall.py
+++ b/inspektor/commands/checkall.py
@@ -88,9 +88,8 @@ class CheckAllCommand(Command):
             self.log.info('License check: disabled')
             license_checker = None
 
-        status = True
+        status = linter.check(checked_paths)
         for path in checked_paths:
-            status &= linter.check(path=path)
             status &= reindenter.check(path=path)
             status &= style_checker.check(path=path)
             if license_checker is not None:

--- a/inspektor/commands/github.py
+++ b/inspektor/commands/github.py
@@ -91,8 +91,6 @@ class GithubCommand(Command):
                             help='Quoted string containing paths or '
                                  'patterns to be excluded from '
                                  'checking, comma separated')
-        parser.add_argument('--verbose', action='store_true',
-                            help='Print extra debug messages')
         return parser
 
     def take_action(self, parsed_args):

--- a/inspektor/commands/indent.py
+++ b/inspektor/commands/indent.py
@@ -35,8 +35,6 @@ class IndentCommand(Command):
                             help='Quoted string containing paths or '
                                  'patterns to be excluded from '
                                  'checking, comma separated')
-        parser.add_argument('--verbose', action='store_true',
-                            help='Print extra debug messages')
         return parser
 
     def take_action(self, parsed_args):

--- a/inspektor/commands/license.py
+++ b/inspektor/commands/license.py
@@ -46,8 +46,6 @@ class LicenseCommand(Command):
                             help='Quoted string containing paths or '
                                  'patterns to be excluded from '
                                  'checking, comma separated')
-        parser.add_argument('--verbose', action='store_true',
-                            help='Print extra debug messages')
         parser.add_argument('--fix', action='store_true', default=False,
                             help='Fix any style problems found '
                                  '(needs autopep8 installed)')

--- a/inspektor/commands/lint.py
+++ b/inspektor/commands/lint.py
@@ -42,8 +42,6 @@ class LintCommand(Command):
                             help='Quoted string containing paths or '
                                  'patterns to be excluded from '
                                  'checking, comma separated')
-        parser.add_argument('--verbose', action='store_true',
-                            help='Print extra debug messages')
         parser.add_argument('--parallel', action='store', nargs='?',
                             default=multiprocessing.cpu_count(),
                             help="How many threads to use")

--- a/inspektor/commands/lint.py
+++ b/inspektor/commands/lint.py
@@ -10,6 +10,7 @@
 # See LICENSE for more details.
 
 import logging
+import multiprocessing
 import os
 
 from cliff.command import Command
@@ -43,6 +44,9 @@ class LintCommand(Command):
                                  'checking, comma separated')
         parser.add_argument('--verbose', action='store_true',
                             help='Print extra debug messages')
+        parser.add_argument('--parallel', action='store', nargs='?',
+                            default=multiprocessing.cpu_count(),
+                            help="How many threads to use")
         return parser
 
     def take_action(self, parsed_args):
@@ -50,10 +54,8 @@ class LintCommand(Command):
             parsed_args.path = [os.getcwd()]
 
         linter = Linter(parsed_args, logger=self.log)
+        status = linter.check(parsed_args.path)
 
-        status = True
-        for path in parsed_args.path:
-            status &= linter.check(path)
         if status:
             self.log.info("Syntax check PASS")
             return 0

--- a/inspektor/commands/style.py
+++ b/inspektor/commands/style.py
@@ -43,8 +43,6 @@ class StyleCommand(Command):
                             help='Quoted string containing paths or '
                                  'patterns to be excluded from '
                                  'checking, comma separated')
-        parser.add_argument('--verbose', action='store_true',
-                            help='Print extra debug messages')
         return parser
 
     def take_action(self, parsed_args):

--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -53,7 +53,6 @@ class Linter(object):
             self.enabled_errors = args.enable_lint
         self.log = logger
         self.args = args
-        self.verbose = args.verbose
         if hasattr(args, 'parallel'):
             self.parallel = args.parallel
         else:
@@ -61,11 +60,8 @@ class Linter(object):
             self.parallel = multiprocessing.cpu_count()
         # Be able to analyze all imports inside the project
         sys.path.insert(0, os.getcwd())
-        if not self.verbose:
-            self.log.info('Pylint disabled: %s' % self.ignored_errors)
-            self.log.info('Pylint enabled : %s' % self.enabled_errors)
-        else:
-            self.log.info('Verbose mode, no disable/enable, full reports')
+        self.log.info('Pylint disabled: %s' % self.ignored_errors)
+        self.log.info('Pylint enabled : %s' % self.enabled_errors)
 
     @staticmethod
     def _pylint_has_option(option):
@@ -80,17 +76,16 @@ class Linter(object):
                        ('--msg-template='
                         '"{msg_id}:{line:3d},{column}: {obj}: {msg}"')]
 
-        if not self.verbose:
-            if self.ignored_errors:
-                pylint_args.append('--disable=%s' % self.ignored_errors)
-            if self.enabled_errors:
-                pylint_args.append('--enable=%s' % self.enabled_errors)
-            if self._pylint_has_option('--reports='):
-                pylint_args.append('--reports=no')
-            if self._pylint_has_option('--score='):
-                pylint_args.append('--score=no')
-            if self._pylint_has_option('--jobs='):
-                pylint_args.append('--jobs=%s' % self.parallel)
+        if self.ignored_errors:
+            pylint_args.append('--disable=%s' % self.ignored_errors)
+        if self.enabled_errors:
+            pylint_args.append('--enable=%s' % self.enabled_errors)
+        if self._pylint_has_option('--reports='):
+            pylint_args.append('--reports=no')
+        if self._pylint_has_option('--score='):
+            pylint_args.append('--score=no')
+        if self._pylint_has_option('--jobs='):
+            pylint_args.append('--jobs=%s' % self.parallel)
 
         return pylint_args
 

--- a/inspektor/lint.py
+++ b/inspektor/lint.py
@@ -60,8 +60,8 @@ class Linter(object):
             self.parallel = multiprocessing.cpu_count()
         # Be able to analyze all imports inside the project
         sys.path.insert(0, os.getcwd())
-        self.log.info('Pylint disabled: %s' % self.ignored_errors)
-        self.log.info('Pylint enabled : %s' % self.enabled_errors)
+        self.log.info('Pylint disabled: %s', self.ignored_errors)
+        self.log.info('Pylint enabled : %s', self.enabled_errors)
 
     @staticmethod
     def _pylint_has_option(option):

--- a/inspektor/style.py
+++ b/inspektor/style.py
@@ -43,7 +43,7 @@ class StyleChecker(object):
         elif hasattr(args, 'disable_style'):
             self.ignored_errors = args.disable_style
         self.args = args
-        self.log.info('PEP8 disabled: %s' % self.ignored_errors)
+        self.log.info('PEP8 disabled: %s', self.ignored_errors)
 
     def check_dir(self, path):
         """

--- a/inspektor/utils/__init__.py
+++ b/inspektor/utils/__init__.py
@@ -36,9 +36,9 @@ def ask(question, auto=False, options="y/n"):
     :param auto: Whether to return "y" instead of asking the question
     """
     if auto:
-        log.info("%s (%s) y" % (question, options))
+        log.info("%s (%s) y", question, options)
         return "y"
-    return input("%s (%s) " % (question, options))
+    return input("%s (%s) ", question, options)
 
 
 def random_string(length, ignore_str=string.punctuation,

--- a/inspektor/utils/vcs.py
+++ b/inspektor/utils/vcs.py
@@ -281,10 +281,10 @@ class GitBackend(object):
 
     def get_repo_name(self):
         """
-        Get tje repository name from git remote command output.
+        Get the repository name from git remote command output.
         """
         cmd = "git remote -v | head -n1 | awk '{print $2}'"
-        cmd += " | sed -e 's,.*:\(.*/\)\?,,' -e 's/\.git$//'"
+        cmd += " | sed -e 's,.*:\\(.*/\\)\\?,,' -e 's/\\.git$//'"
         return process.run(cmd, verbose=False, shell=True).stdout.strip()
 
     def get_unknown_files(self):

--- a/inspektor/utils/vcs.py
+++ b/inspektor/utils/vcs.py
@@ -234,8 +234,8 @@ class SubVersionBackend(object):
     def update(self):
         try:
             process.run("svn update")
-        except exceptions.CmdError as e:
-            self.log.error("SVN tree update failed: %s" % e)
+        except exceptions.CmdError as details:
+            self.log.error("SVN tree update failed: %s", details)
 
     def get_modified_files_patch(self, untracked_files_before, patch):
         """
@@ -376,8 +376,7 @@ class GitBackend(object):
             process.run("git checkout -b %s" % branch,
                         verbose=False)
         except exceptions.CmdError:
-            self.log.error("branch %s already exists!"
-                           % branch)
+            self.log.error("branch %s already exists!", branch)
             answer = ask("What would you like to do?",
                          options="Abort/Delete/Rename/OldBase/NewBase")
             if not answer:
@@ -427,15 +426,16 @@ class GitBackend(object):
                 process.run("git checkout -b %s" % branch, verbose=False)
         try:
             process.run("git am -3 %s" % patch, verbose=False)
-        except exceptions.CmdError as e:
-            self.log.error("Failed to apply patch to the git repo: %s" % e)
+        except exceptions.CmdError as details:
+            self.log.error("Failed to apply patch to the git repo: %s",
+                           details)
             return 1
 
     def update(self):
         try:
             process.run("git pull", verbose=False)
-        except exceptions.CmdError as e:
-            self.log.error("git tree update failed: %s" % e)
+        except exceptions.CmdError as details:
+            self.log.error("git tree update failed: %s", details)
 
     def get_modified_files_patch(self, untracked_files_before, patch):
         """


### PR DESCRIPTION
The first commit adds "parallel" execution of "inspekt lint" and the second one removes the "--verbose" mode from all sub-commands, because it is not really passed as an argument. Partially it works in the sense the loggers are set by the main app to DEBUG vs. INFO leading to some messages being printed, but the different setting for lint does not work. As this issue is with us for quite a while I choose to remove it and keep only to already working DEBUG vs. INFO part as it might be useful to people.

__Note: It'd be nice to release new inspektor with this commit to speedup the Travis executions.__